### PR TITLE
added no df option

### DIFF
--- a/experiments/add_sf_to_df_add_row.R
+++ b/experiments/add_sf_to_df_add_row.R
@@ -36,7 +36,7 @@ debugger;
 
 
 
-make_an_sf <- function(dat, zoomto = NULL){
+make_an_sf <- function(dat = NULL, zoomto = NULL){
 
   APP_CRS <- 4326
 
@@ -116,6 +116,17 @@ make_an_sf <- function(dat, zoomto = NULL){
         data_copy$leaflet_id <- NA # may need to redo this each time?
       }
 
+    } else if (is.null(dat)){
+
+      dat <- data.frame(id = 'CHANGE ME', comments = 'ADD COMMENTS...')
+
+      data_copy <- st_as_sf(
+        dat,
+        geometry = st_sfc(lapply(seq_len(nrow(dat)),function(i){st_point()}))
+      ) %>% st_set_crs(APP_CRS)
+
+      # add column for leaflet id, since we will need to track layer id to offer zoom to
+      data_copy$leaflet_id <- NA
     }
 
 


### PR DESCRIPTION
Not a huge fan of dat = NULL as argument but missing(dat) is not working... This allows the user to just create without any prior data.frame. The colnames and attribute language can change but what do you think? Really digging the zoom argument as well! And the button mods! 